### PR TITLE
Match Package.swift platforms with CryptoSwift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,9 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftOTP",
+    platforms: [
+        .macOS(.v10_12), .iOS(.v9), .tvOS(.v9), .watchOS(.v4)
+    ],
     products: [
         .library(name: "SwiftOTP", targets: ["SwiftOTP"]),
     ],


### PR DESCRIPTION
Adding SwiftOTP to an Xcode project via File > Swift Package > Add Package Dependency will cause SwiftOTP to fail compilation with this error: 

<img width="739" alt="image" src="https://user-images.githubusercontent.com/14804033/94343061-e570e500-ffeb-11ea-977e-217635fc5da6.png">

This PR addresses this issue by matching the platforms on `Package.swift` with the ones [defined in CryptoSwift](https://github.com/krzyzanowskim/CryptoSwift/blob/af1b58fc569bfde777462349b9f7314b61762be0/Package.swift#L8)