### PR TITLE
Avoiding try! in Generator class

### DIFF
--- a/SwiftOTP/Generator.swift
+++ b/SwiftOTP/Generator.swift
@@ -53,7 +53,7 @@ internal class Generator {
 		let counterMessage = counter.bigEndian.data
 		
 		// HMAC hash counter data with secret key
-		let hmac = try! HMAC(key: key, variant: algorithm.hmacVariant).authenticate(counterMessage.bytes)
+		guard let hmac = try? HMAC(key: key, variant: algorithm.hmacVariant).authenticate(counterMessage.bytes) else { return nil }
 		
 		// Get last 4 bits of hash as offset
 		let offset = Int((hmac.last ?? 0x00) & 0x0f)


### PR DESCRIPTION
Fairly simple change, safely unwrapping `try` since the generator method allows returning an optional String