### PR TITLE
Add Equatable conformance to TOTP and HOTP

### DIFF
--- a/SwiftOTP/HOTP.swift
+++ b/SwiftOTP/HOTP.swift
@@ -34,7 +34,7 @@
 import Foundation
 
 /// Counter-based one time password object
-public struct HOTP {
+public struct HOTP: Equatable {
 	public let secret: Data
 	public let digits: Int
 	public let algorithm: OTPAlgorithm

--- a/SwiftOTP/TOTP.swift
+++ b/SwiftOTP/TOTP.swift
@@ -34,7 +34,7 @@
 import Foundation
 
 /// Time-based one time password object
-public struct TOTP {
+public struct TOTP: Equatable {
 	public let secret: Data
 	public let digits: Int
 	public let timeInterval: Int


### PR DESCRIPTION
Adopted `Equatable` in `TOTP` and `HOTP`, relying on automatic synthesis of the protocol’s requirements. 