### PR TITLE
[deps] Update swift crypto dependency range

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,8 @@ let package = Package(
         .library(name: "SwiftOTP-Dynamic", type: .dynamic, targets: ["SwiftOTP"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "1.0.0"))
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" 
+..< "4.0.0")
     ],
     targets: [
         .target(name: "SwiftOTP", dependencies: ["Crypto"], path: "SwiftOTP/"),


### PR DESCRIPTION
We should update the allowed version range for swift crypto as it recommends using version ranges between 1.0.0 < 4.0.0