### PR TITLE
Use swift-crypto 4.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "SwiftOTP-Dynamic", type: .dynamic, targets: ["SwiftOTP"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "4.2.0")
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0" ..< "5.0.0")
     ],
     targets: [
         .target(name: "SwiftOTP", dependencies: ["Crypto"], path: "SwiftOTP/"),

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,7 @@ let package = Package(
         .library(name: "SwiftOTP-Dynamic", type: .dynamic, targets: ["SwiftOTP"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" 
-..< "4.0.0")
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "4.2.0")
     ],
     targets: [
         .target(name: "SwiftOTP", dependencies: ["Crypto"], path: "SwiftOTP/"),


### PR DESCRIPTION
I've updated the swift-crypto dependency to version 4.2.0. My project builds and works as expected. I haven’t tested every aspect thoroughly, but I believe everything should be fine.