### PR TITLE
Swift crypto 4.x.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "SwiftOTP-Dynamic", type: .dynamic, targets: ["SwiftOTP"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0" ..< "5.0.0")
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "5.0.0")
     ],
     targets: [
         .target(name: "SwiftOTP", dependencies: ["Crypto"], path: "SwiftOTP/"),

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "SwiftOTP-Dynamic", type: .dynamic, targets: ["SwiftOTP"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "4.2.0")
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0" ..< "5.0.0")
     ],
     targets: [
         .target(name: "SwiftOTP", dependencies: ["Crypto"], path: "SwiftOTP/"),

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,7 @@ let package = Package(
         .library(name: "SwiftOTP-Dynamic", type: .dynamic, targets: ["SwiftOTP"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" 
-..< "4.0.0")
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "4.2.0")
     ],
     targets: [
         .target(name: "SwiftOTP", dependencies: ["Crypto"], path: "SwiftOTP/"),


### PR DESCRIPTION
This PR fixes typo made in https://github.com/lachlanbell/SwiftOTP/pull/48

```
Updating https://github.com/lachlanbell/SwiftOTP
Updated https://github.com/lachlanbell/SwiftOTP (0.41s)
error: Invalid manifest (compiled with: [...])
/Package.swift:14:82: error: cannot convert value of type 'Range<String>' to expected argument type 'Version'
12 |     ],
13 |     dependencies: [
14 |         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0" ..< "5.0.0")
   |                                                                                  `- error: cannot convert value of type 'Range<String>' to expected argument type 'Version'
15 |     ],
16 |     targets: [ in https://github.com/lachlanbell/SwiftOTP

   ```